### PR TITLE
fixed wrong annotation name

### DIFF
--- a/src/main/java/org/datanucleus/api/jpa/annotations/IndexHandler.java
+++ b/src/main/java/org/datanucleus/api/jpa/annotations/IndexHandler.java
@@ -35,7 +35,7 @@ public class IndexHandler implements MemberAnnotationHandler
     {
         Map<String, Object> annotationValues = ann.getNameValueMap();
         String name = (String)annotationValues.get("name");
-        Boolean unique = (Boolean)annotationValues.get("name");
+        Boolean unique = (Boolean)annotationValues.get("unique");
         IndexMetaData idxmd = mmd.getIndexMetaData();
         if (idxmd == null)
         {


### PR DESCRIPTION
Using the @Index-Annotation led to a ClassCastException:
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Boolean
    at org.datanucleus.api.jpa.annotations.IndexHandler.processMemberAnnotation(IndexHandler.java:38)

This should fix it, but its untested.
